### PR TITLE
Refactoring & Improvements

### DIFF
--- a/images.nix
+++ b/images.nix
@@ -1,78 +1,46 @@
 # How to build an image from this file:
-#   nix-build images.nix -A \"node-v10-php-7.1-ruby-2.3\"
+#   nix-build f1ux.nix -A \"node-v10-php-7.1-ruby-2.3\"
 #
 # The escapes are needed since "node-v10-php-7.1-ruby-2.3" doesn't follow Nix's normal rules for attribute names
 let
   pkgs = import <nixpkgs> {};
   inherit (pkgs) pkgsStatic runCommand lib dockerTools;
 
+  util = import ../util.nix;
+
   # Import the various node/php/ruby versions we support
-  nodeVersions = import ./node.nix;
-  phpVersions = import ./php.nix;
-  rubyVersions = import ./ruby.nix;
+  nodeVersions = import ../node.nix;
+  phpVersions = import ../php.nix;
+  rubyVersions = import ../ruby.nix;
 
-  # Helper to create iteration functions
-  mkEach = obj: fn: builtins.map fn (builtins.attrNames obj);
-
-  # Iteration functions for the versions
-  eachNode = mkEach nodeVersions;
-  eachPhp = mkEach phpVersions;
-  eachRuby = mkEach rubyVersions;
-
-  tags =
-    let
-      # This is an attribute set of node and php versions in each possible iteration -
-      # that is, the keys are "node-(version)-php-(version)", such as "node-v4-php-7.3"
-      # and "node-v10-php-7.3".
-      # The values of the attribute set are an attrset of derivations to install into the
-      # Docker image built below.
-      node-php =
-        builtins.concatLists
-          (
-            eachNode (
-              nodeKey:
-                eachPhp (
-                  phpKey:
-                    let
-                      # Install node and grunt together
-                      node = nodeVersions.${nodeKey};
-                      grunt = import ./grunt.nix { inherit node; };
-
-                      # Install PHP and composer together
-                      php = phpVersions.${phpKey};
-                      composer = import ./composer.nix { inherit php; };
-                    in
-                    {
-                      name = "node-${nodeKey}-php-${phpKey}";
-                      value = { inherit node grunt php composer; };
-                    }
-                )
-            )
-          );
-
-      # This is the full combination of node, php, and ruby together. This is broken out
-      # because the cross product of three lists is ugly to write, so it's (hopefully)
-      # an improvement in readability to do it this way.
-      node-php-ruby =
-        builtins.concatLists
-          (
-            lib.forEach node-php
-              (
-                { name, value }: eachRuby (
-                  rubyKey:
-                    let
-                      ruby = rubyVersions.${rubyKey};
-                      bundler = import ./bundler.nix { inherit ruby; };
-                    in
-                    {
-                      name = "${name}-ruby-${rubyKey}";
-                      value = value // { inherit ruby bundler; };
-                    }
-                )
-              )
-          );
-    in
-    builtins.listToAttrs node-php-ruby;
+  # Builds the attrset of tag => { node grunt php composer ruby bundler } that varies
+  # based on the node/php/ruby versions
+  tags = util.tagMatrix [
+    {
+      name = "node";
+      versions = nodeVersions;
+      build = node: {
+        inherit node;
+        grunt = import ../grunt.nix { inherit node; };
+      };
+    }
+    {
+      name = "php";
+      versions = phpVersions;
+      build = php: {
+        inherit php;
+        composer = import ../composer.nix { inherit php; };
+      };
+    }
+    {
+      name = "ruby";
+      versions = rubyVersions;
+      build = ruby: {
+        inherit ruby;
+        bundler = import ../bundler.nix { inherit ruby; };
+      };
+    }
+  ];
 
   # Utilities needed at runtime: bash, coreutils, and git. pkgs.cacert is needed for git
   # to be able to ls-remote against GitHub and other sources.
@@ -119,54 +87,52 @@ let
     tempdir
     symlinks
   ];
+
+  builder = tag: { ruby, ... }@packages:
+    let
+      runtimePath = builtins.concatStringsSep ":" [
+        # Default $PATH in Docker images
+        "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        # Make sure grunt is accessible
+        "/lib/node_modules/.bin"
+        # Make sure installed gem scripts (e.g., cap, compass) are accessible
+        "${ruby}/bin"
+      ];
+    in
+    dockerTools.buildLayeredImage {
+      name = "forumone/f1ux";
+      inherit tag;
+
+      # Force nix to set the creation date to now for better discoverability by install
+      # date (the default is a fixed date for image reproducibility reasons)
+      created = "now";
+
+      # This image has quite a few layers, so we ask nix to use most of the available
+      # space when spreading images out.
+      maxLayers = 120;
+
+      # Concatenate the lists of things to install
+      contents = builtins.concatLists [
+        (builtins.attrValues packages)
+        development
+        utilities
+        paths
+      ];
+
+      config = {
+        # Set the default script to bash
+        Cmd = "${pkgs.bashInteractive}/bin/bash";
+
+        # Set the working directory to /app
+        WorkingDir = "/app";
+
+        # Add the updated $PATH and ask git to look at the installed cacert bundle
+        Env = [
+          "PATH=${runtimePath}"
+          "GIT_SSL_CAPATH=/etc/ssl/certs/ca-bundle.crt"
+          "GIT_SSL_CAINFO=/etc/ssl/certs/ca-bundle.crt"
+        ];
+      };
+    };
 in
-builtins.mapAttrs
-  (
-    tag: { ruby, ... }@packages:
-      let
-        runtimePath = builtins.concatStringsSep ":" [
-          # Default $PATH in Docker images
-          "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-          # Make sure grunt is accessible
-          "/lib/node_modules/.bin"
-          # Make sure installed gem scripts (e.g., cap, compass) are accessible
-          "${ruby}/bin"
-        ];
-      in
-      dockerTools.buildLayeredImage {
-        name = "forumone/f1ux";
-        inherit tag;
-
-        # Force nix to set the creation date to now for better discoverability by install
-        # date (the default is a fixed date for image reproducibility reasons)
-        created = "now";
-
-        # This image has quite a few layers, so we ask nix to use most of the available
-        # space when spreading images out.
-        maxLayers = 120;
-
-        # Concatenate the lists of things to install
-        contents = builtins.concatLists [
-          (builtins.attrValues packages)
-          development
-          utilities
-          paths
-        ];
-
-        config = {
-          # Set the default script to bash
-          Cmd = "${pkgs.bashInteractive}/bin/bash";
-
-          # Set the working directory to /app
-          WorkingDir = "/app";
-
-          # Add the updated $PATH and ask git to look at the installed cacert bundle
-          Env = [
-            "PATH=${runtimePath}"
-            "GIT_SSL_CAPATH=/etc/ssl/certs/ca-bundle.crt"
-            "GIT_SSL_CAINFO=/etc/ssl/certs/ca-bundle.crt"
-          ];
-        };
-      }
-  )
-  tags
+builtins.mapAttrs builder tags

--- a/images.nix
+++ b/images.nix
@@ -6,12 +6,12 @@ let
   pkgs = import <nixpkgs> {};
   inherit (pkgs) pkgsStatic runCommand lib dockerTools;
 
-  util = import ../util.nix;
+  util = import ./util.nix;
 
   # Import the various node/php/ruby versions we support
-  nodeVersions = import ../node.nix;
-  phpVersions = import ../php.nix;
-  rubyVersions = import ../ruby.nix;
+  nodeVersions = import ./node.nix;
+  phpVersions = import ./php.nix;
+  rubyVersions = import ./ruby.nix;
 
   # Builds the attrset of tag => { node grunt php composer ruby bundler } that varies
   # based on the node/php/ruby versions
@@ -21,7 +21,7 @@ let
       versions = nodeVersions;
       build = node: {
         inherit node;
-        grunt = import ../grunt.nix { inherit node; };
+        grunt = import ./grunt.nix { inherit node; };
       };
     }
     {
@@ -29,7 +29,7 @@ let
       versions = phpVersions;
       build = php: {
         inherit php;
-        composer = import ../composer.nix { inherit php; };
+        composer = import ./composer.nix { inherit php; };
       };
     }
     {
@@ -37,7 +37,7 @@ let
       versions = rubyVersions;
       build = ruby: {
         inherit ruby;
-        bundler = import ../bundler.nix { inherit ruby; };
+        bundler = import ./bundler.nix { inherit ruby; };
       };
     }
   ];

--- a/node.nix
+++ b/node.nix
@@ -34,7 +34,9 @@ let
       ];
     in
     stdenv.mkDerivation {
-      name = "node-${name}";
+      pname = "node";
+      inherit version;
+
       src = fetchurl {
         url = "https://nodejs.org/dist/${version}/node-${version}.tar.xz";
         sha256 = sha256;

--- a/node.nix
+++ b/node.nix
@@ -16,18 +16,13 @@ let
       # Import nixpkgs and the standard environment
       pkgs = import <nixpkgs> {};
 
-      # This should be a static python, but for some reason that breaks
-      inherit (pkgs) python2 pkgsStatic;
-      inherit (pkgsStatic) stdenv fetchurl;
+      inherit (pkgs) stdenv fetchurl python2;
 
       # Use specific configure flags because stdenv's defaults confuse the custom
       # configure script.
       configureFlags = [
         # Build to the $out path
         "--prefix" "$out"
-
-        # Statically link
-        "--fully-static"
 
         # Don't generate v8 snapshots
         "--without-snapshot"
@@ -44,7 +39,6 @@ let
 
       enableParallelBuilding = true;
 
-      buildInputs = [python2];
       nativeBuildInputs = [python2];
 
       # Point build scripts to the exact Nix store paths rather than /usr/bin/env

--- a/php.nix
+++ b/php.nix
@@ -25,11 +25,15 @@ let
       inherit (pkgs.pkgsStatic) stdenv lib fetchurl;
       inherit (pkgs.pkgsStatic) pkgconfig libxml2 zlib;
 
-      # Static oniguruma (this is pending an upstream merge in nixpkgs)
+      # Static oniguruma - this override is here because we are waiting on these PRs:
+      # * https://github.com/NixOS/nixpkgs/pull/75950 (static oniguruma)
+      # * https://github.com/NixOS/nixpkgs/pull/76659 (generalizes the above for CMake-based libraries)
       oniguruma = pkgs.pkgsStatic.oniguruma.overrideAttrs (_: {
         cmakeFlags = ["-DBUILD_SHARED_LIBS=OFF"];
       });
 
+      # This is not yet in a PR, but we should likely wait until nixpkgs#76659 is merged
+      # in order to avoid
       libzip = pkgs.pkgsStatic.libzip.overrideAttrs ({ cmakeFlags ? [], ... }: {
         cmakeFlags = cmakeFlags ++ [ "-DBUILD_SHARED_LIBS=OFF" "-DBUILD_REGRESS=OFF" ];
       });

--- a/php.nix
+++ b/php.nix
@@ -36,7 +36,9 @@ let
         else "--with-libxml-dir=${libxml2.dev}";
     in
     stdenv.mkDerivation {
-      name = "php-${name}";
+      pname = "php";
+      inherit version;
+
       src = fetchurl {
         url = "https://www.php.net/distributions/php-${version}.tar.bz2";
         inherit sha256;

--- a/php.nix
+++ b/php.nix
@@ -6,12 +6,10 @@ let
   util = import ./util.nix;
 
   versions = [
-    # bleah, oniguruma
-    # { version = "7.4.0"; sha256 = "bf206be96a39e643180013df39ddcd0493966692a2422c4b7d3355b6a15a01c0"; }
-
     # The sha256 digest here is for the .tar.bz2 files of the PHP source distribution
-    { version = "7.3.12"; sha256 = "d317b029f991410578cc38ba4b76c9f764ec29c67e7124e1fec57bceb3ad8c39"; }
-    { version = "7.2.25"; sha256 = "7cb336b1ed0f9d87f46bbcb7b3437ee252d0d5060c0fb1a985adb6cbc73a6b9e"; }
+    { version = "7.4.1"; sha256 = "6b1ca0f0b83aa2103f1e454739665e1b2802b90b3137fc79ccaa8c242ae48e4e"; }
+    { version = "7.3.13"; sha256 = "5c7b89062814f3c3953d1518f63ed463fd452929e3a37110af4170c5d23267bc"; }
+    { version = "7.2.26"; sha256 = "f36d86eecf57ff919d6f67b064e1f41993f62e3991ea4796038d8d99c74e847b"; }
     { version = "7.1.33"; sha256 = "95a5e5f2e2b79b376b737a82d9682c91891e60289fa24183463a2aca158f4f4b"; }
     { version = "7.0.33"; sha256 = "4933ea74298a1ba046b0246fe3771415c84dfb878396201b56cb5333abe86f07"; }
     { version = "5.6.40"; sha256 = "ffd025d34623553ab2f7fd8fb21d0c9e6f9fa30dc565ca03a1d7b763023fba00"; }
@@ -26,6 +24,11 @@ let
       # This derivation uses static links to reduce the build output's size
       inherit (pkgs.pkgsStatic) stdenv lib fetchurl;
       inherit (pkgs.pkgsStatic) pkgconfig libxml2;
+
+      # Static oniguruma (this is pending an upstream merge in nixpkgs)
+      oniguruma = pkgs.pkgsStatic.oniguruma.overrideAttrs (_: {
+        cmakeFlags = ["-DBUILD_SHARED_LIBS=OFF"];
+      });
 
       libxmlFlag =
         if lib.versionAtLeast version "7.1"
@@ -45,6 +48,7 @@ let
       buildInputs = with (pkgs.pkgsStatic); [
         libxml2
         zlib
+        oniguruma
       ];
 
       nativeBuildInputs = with (pkgs.pkgsStatic); [

--- a/ruby.nix
+++ b/ruby.nix
@@ -34,7 +34,9 @@ let
       versionKey = "${name}.0";
     in
     stdenv.mkDerivation {
-      name = "ruby-${name}";
+      pname = "ruby";
+      inherit version;
+
       inherit src;
 
       # Passes -j$(nproc) to make during the build phase

--- a/ruby.nix
+++ b/ruby.nix
@@ -29,14 +29,6 @@ let
         inherit sha256;
       };
 
-      # Ruby's configure has trouble with static extensions, so we just point it to these
-      # build paths directly.
-      # We only use zlib and openssl since they're needed for `gem install` and friends
-      environment = with (pkgs.pkgsStatic); {
-        CFLAGS = "-I${zlib.dev}/include -I${openssl.dev}/include";
-        LDFLAGS = "-L${zlib.static}/lib -L${openssl.out}/lib";
-      };
-
       # Ruby gems are packaged by X.Y.0 versions, no matter what the actual patch-level
       # version is, so we can just statically predict it here
       versionKey = "${name}.0";
@@ -48,8 +40,10 @@ let
       # Passes -j$(nproc) to make during the build phase
       enableParallelBuilding = true;
 
-      CFLAGS = environment.CFLAGS;
-      LDFLAGS = environment.LDFLAGS;
+      buildInputs = with (pkgs.pkgsStatic); [
+        openssl
+        zlib
+      ];
 
       configureFlags = [
         # Don't use GCC for the JIT

--- a/util.nix
+++ b/util.nix
@@ -63,7 +63,7 @@ let
   # Usage:
   #   crossProduct (x: y: ...) "" [[...] [...] [...]]
   #
-  # Computs the cross product of an arbitrary number of lists. Generalization of nixpkgs'
+  # Computes the cross product of an arbitrary number of lists. Generalization of nixpkgs'
   # lib.crossLists.
   crossProduct = f: nil: lists:
     builtins.foldl'

--- a/util.nix
+++ b/util.nix
@@ -1,7 +1,7 @@
 let
   lib = import <nixpkgs/lib>;
 
-  # Example usage:
+  # Usage:
   #   builtins..map (mkVersion { key = str: ...; }) [...]
   #
   # This creates a helper function that extracts a key from a version, and is intended
@@ -46,7 +46,73 @@ let
       versionAttrs = mkVersions { inherit key; } versions;
     in
     builtins.mapAttrs (lib.const mkDerivation) versionAttrs;
+
+  # Usage:
+  #   attrsToList { ... }
+  #
+  # Converts an attrset to a list of name/value pairs.
+  #
+  # The following identities should hold for all x:
+  # 1. attrsToList (builtins.listToAttrs x) = x
+  # 2. builtins.listToAttrs (attrsToList x) = x
+  attrsToList = attrs:
+    builtins.map
+      (name: { inherit name; value = attrs.${name}; })
+      (builtins.attrNames attrs);
+
+  # Usage:
+  #   crossProduct (x: y: ...) "" [[...] [...] [...]]
+  #
+  # Computs the cross product of an arbitrary number of lists. Generalization of nixpkgs'
+  # lib.crossLists.
+  crossProduct = f: nil: lists:
+    builtins.foldl'
+      (x: y: lib.crossLists f [x y])
+      [nil]
+      lists;
+
+  # Usage:
+  #   join "foo" "bar"
+  #
+  # Combines the two arguments with a hyphen. If x is the empty string, just outputs y.
+  join = x: y:
+    if x != "" then "${x}-${y}"
+    else y;
+
+  # Usage:
+  #   tagMatrix [ { name = ...; versions = [...]; build = x: { ... }; }]
+  #
+  # Creates an attrset from a list of descriptions on how to produce a set of values from
+  # a given version. This function is primarily intended for the case of building a Docker
+  # image where the attrset's names represent the tags to use, and the values are an
+  # attrset of derivations that depend on the elements.
+  tagMatrix = builds:
+    let
+      # The default build function simply
+      mkBuild = name: value: builtins.listToAttrs [
+        { inherit name value; }
+      ];
+
+      mapper = { name, versions, build ? mkBuild name }:
+        attrsToList (lib.mapAttrs'
+          (key: drv: {
+            name = join name key;
+            value = build drv;
+          })
+          versions);
+
+      inputs = builtins.map mapper builds;
+
+      product = crossProduct
+        (x: y: {
+          name = join x.name y.name;
+          value = x.value // y.value;
+        })
+        { name = ""; value = {}; }
+        inputs;
+    in
+    builtins.listToAttrs product;
 in
 {
-  inherit mkVersion mkVersions mkMatrix;
+  inherit mkVersion mkVersions mkMatrix attrsToList crossProduct join tagMatrix;
 }


### PR DESCRIPTION
Summary:

* The logic to create the matrix of language runtimes has been extracted into its own function in `util.nix`.
* Per upstream nixpkgs convention, derivations are now named with `pname` and `version`.
* The handling of `buildInputs` and `nativeBuildInputs` have been improved based on some discussions with the Nix community.
* PHP is now built with the extensions needed to run Composer and Pattern Lab for Gesso 2.x.
* By addressing libxml and oniguruma issues, we can build PHP from 5.6 up to 7.4, which should improve compatibility both with very old Pattern Lab installations and potential upcoming changes to the Twig renderer in Pattern Lab.
* Node is no longer static in order to support `node-sass` for Gesso 2.x and 3.x.