### PR TITLE
Add phantomjs to f1ux images

### DIFF
--- a/f1ux/generic.nix
+++ b/f1ux/generic.nix
@@ -8,6 +8,9 @@
 , bashInteractive, coreutils, file
 , gnumake, gnused, gnugrep, gawk, diffutils, binutils, binutils-unwrapped
 
+  # PhantomJS
+, fontconfig, phantomjs-prebuilt_19
+
   # Paths
 , composerTemp, usrBinEnv
 
@@ -59,6 +62,10 @@ dockerTools.buildLayeredImage {
     gawk
     diffutils
     binutils
+
+    # PhantomJS
+    fontconfig.out
+    phantomjs-prebuilt_19
 
     # Paths needed in the image
     composerTemp


### PR DESCRIPTION
This PR makes PhantomJS available in f1ux-based images, much like Gesso 2.x.