### PR TITLE
Do better at fixing CA bundle paths

### DIFF
--- a/f1ux/generic.nix
+++ b/f1ux/generic.nix
@@ -12,7 +12,7 @@
 , bzip2, fontconfig, gnutar, resolve-all-libraries
 
   # Paths
-, composerTemp, usrBinEnv
+, composerTemp, usrBinEnv, certPath, gitCertPath
 
   # Languages & tools
 , node, grunt
@@ -74,6 +74,7 @@ dockerTools.buildLayeredImage {
     composerTemp
     symlinks
     usrBinEnv
+    certPath
 
     # Node.js
     node
@@ -95,8 +96,8 @@ dockerTools.buildLayeredImage {
 
     Env = [
       "PATH=${util.dockerPath}:${ruby23}/bin"
-      "GIT_SSL_CAPATH=/etc/ssl/certs/ca-certificates.crt"
-      "GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt"
+      "GIT_SSL_CAPATH=${gitCertPath}"
+      "GIT_SSL_CAINFO=${gitCertPath}"
     ];
   };
 }

--- a/gesso2/generic.nix
+++ b/gesso2/generic.nix
@@ -14,6 +14,7 @@
 
   # Paths
 , composerTemp, certPath, usrBinEnv
+, gitCertPath
 
   # Languages & tools
 , node, grunt
@@ -53,8 +54,8 @@ dockerTools.buildLayeredImage {
     WorkingDir = "/app";
     Env = [
       "PATH=${util.dockerPath}"
-      "GIT_SSL_CAPATH=/etc/ssl/certs/ca-certificates.crt"
-      "GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt"
+      "GIT_SSL_CAPATH=${gitCertPath}"
+      "GIT_SSL_CAINFO=${gitCertPath}"
     ];
   };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -14,6 +14,10 @@ in
     withManual = false;
   };
 
+  # Full path to cacert's bundle. We save this here to avoid issues with keeping the
+  # certificate paths in sync for the f1ux and gesso2 derivations.
+  gitCertPath = "${self.cacert}/etc/ssl/certs/ca-bundle.crt";
+
   # Add utilities
   util = import ./util.nix { inherit (self) lib; };
 


### PR DESCRIPTION
This PR introduces two changes:

1. It shares the `certPath` derivation between Gesso 2 and f1ux images in order to placate OpenSSL
2. It uses a shared constant for the exact path to the CA bundle for git.

These changes address an issue with the f1ux images where the CA path for git was set to `/etc/ssl/certs/ca-certificates.crt`, which didn't exist in the image. By using the full path, we will immunize ourselves from future issues. Nix's Docker build tools scan the environment configuration for paths it needs to include in the image, so we won't run into this issue again.