### PR TITLE
Downgrade Ruby OpenSSL to 1.0.2u

### DIFF
--- a/ruby.nix
+++ b/ruby.nix
@@ -1,7 +1,7 @@
 {
   stdenv, fetchurl, lib
 
-, openssl, zlib
+, openssl_1_0_2, zlib
 }:
 let
   generic =
@@ -22,7 +22,7 @@ let
       enableParallelBuilding = true;
 
       buildInputs = [
-        openssl
+        openssl_1_0_2
         zlib
       ];
 


### PR DESCRIPTION
When nixpkgs switched to OpenSSL 1.1 by default, it left our Ruby 2.3 derivation behind, which silently disables the `openssl` extension if it can't be configured correctly. This downgrades the OpenSSL version back to 1.0.2u, which will successfully configure and build.