### PR TITLE
Updates to align with upstream nixpkgs

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -33,24 +33,9 @@ in
   certPath = self.callPackage ./certPath.nix {};
   usrBinEnv = self.callPackage ./usrBinEnv.nix {};
 
-  # Add node versions and expose shorthand for node & grunt
+  # Add PHP & node versions
   inherit nodeVersions;
-  inherit (nodeVersions)
-    node12 grunt12
-    node10 grunt10
-    node8 grunt8
-    node6 grunt6
-    node4 grunt4;
-
-  # Add PHP versions and expose shorthand for php & grunt
   inherit phpVersions;
-  inherit (phpVersions)
-    php74 composer74
-    php73 composer73
-    php72 composer72
-    php71 composer71
-    php70 composer70
-    php56 composer56;
 
   # Add the image sets
   f1ux = self.callPackage ./f1ux {};

--- a/php.nix
+++ b/php.nix
@@ -98,6 +98,8 @@ let
         "--enable-ctype=static"
         "--enable-zip=static"
         "--with-zlib-dir=${zlib.dev}"
+
+        "PKG_CONFIG=${pkgconfig}/bin/${pkgconfig.targetPrefix}pkg-config"
       ];
 
       passthru = {

--- a/php.nix
+++ b/php.nix
@@ -125,8 +125,8 @@ let
   # are a path in nixpkgs root, arriving at [2]) directly, replacing nixpkgs' PHP with the
   # one custom-built in this file.
   #
-  # [1]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/php-packages.nix [2]:
-  # https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/php-packages/composer/default.nix
+  # [1]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/php-packages.nix
+  # [2]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/php-packages/composer/default.nix
   composer = php:
     let
       mkDerivation = { pname, ... }@args:

--- a/php.nix
+++ b/php.nix
@@ -1,6 +1,6 @@
 {
   # Nix library elements
-  stdenv, lib, fetchurl
+  stdenv, lib, fetchurl, newScope
 
   # Builders
 , writeTextFile, runCommand, makeWrapper
@@ -117,7 +117,24 @@ let
       outputs = [ "out" "dev" ];
     };
 
-  composer = php: (phpPackages.override { inherit php; }).composer;
+  # Create a new callPackage function specific to this PHP version. This is the idiom used
+  # by upstream nixpkgs in order to create PHP-specific derivations (see, e.g., [1]). By
+  # adopting this idiom ourselves, we can use the Composer derivation (the angle brackets
+  # are a path in nixpkgs root, arriving at [2]) directly, replacing nixpkgs' PHP with the
+  # one custom-built in this file.
+  #
+  # [1]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/php-packages.nix [2]:
+  # https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/php-packages/composer/default.nix
+  composer = php:
+    let
+      mkDerivation = { pname, ... }@args:
+        stdenv.mkDerivation (args // { pname = "php-${pname}"; });
+
+      callPackage = newScope {
+        inherit mkDerivation php;
+      };
+    in
+    callPackage <nixpkgs/pkgs/development/php-packages/composer> {};
 
   # Creates a config file to remove the PHP memory limit
   memoryLimitConfig = writeTextFile {


### PR DESCRIPTION
This PR makes two changes to work with changes in upstream nixpkgs:

1. The `phpPackages` object is no longer overridable, so we use nixpkgs' own `callPackage` mechanism to get a Composer that is associated with these images' custom-built PHP. (See the comments for more details on how this works.)
2. PHP's `./configure` script isn't aware of the new `pkg-config` wrapper in use by nixpkgs (see NixOS/nixpkgs#87705), so we manually inject the name of the wrapped `pkg-config`. Without this change, configure reports an error where it can't find the OpenSSL libraries.