### PR TITLE
Version bumps

### DIFF
--- a/node.nix
+++ b/node.nix
@@ -31,6 +31,9 @@ let
     in
     "v${lib.versions.major slice}";
 
+  # Usage:
+  # * version: Full Node.js version (e.g., v4.9.1)
+  # * sha256: SHA256 checksum of the .tar.xz source archive
   generic =
     { version, sha256 }:
     stdenv.mkDerivation {
@@ -93,10 +96,10 @@ let
 
 in rec {
   # The sha256 digest here is for the .tar.xz of the Node sources
-  node12 = generic { version = "v12.14.1"; sha256 = "877b4b842318b0e09bc754faf7343f2f097f0fc4f88ab9ae57cf9944e88e7adb"; };
+  node12 = generic { version = "v12.22.4"; sha256 = "44cd4eab131e5282fc923e9e720d983a0b44c12e4aa4f6c3598dc97ae1e4cd4c"; };
   grunt12 = grunt node12;
 
-  node10 = generic { version = "v10.18.1"; sha256 = "39af1837f439af7b4dc40ec18a64221c688c3982858168ae535bbe4911e8ea35"; };
+  node10 = generic { version = "v10.24.1"; sha256 = "d72fc2c244603b4668da94081dc4d6067d467fdfa026e06a274012f16600480c"; };
   grunt10 = grunt node10;
 
   node8 = generic { version = "v8.17.0"; sha256 = "5b0d96db482b273f0324c299ead86ecfbc5d033516e5fc37c92cfccb933ef6ff"; };

--- a/php.nix
+++ b/php.nix
@@ -15,6 +15,9 @@
 , phpPackages
 }:
 let
+  # Usage:
+  # * version: Full PHP version (e.g., 7.1.33)
+  # * sha256: SHA256 checksum of the .tar.bz2 source archive
   generic =
     { version, sha256 }:
     let
@@ -158,13 +161,14 @@ let
     '';
 in
 rec {
-  php74 = generic { version = "7.4.1"; sha256 = "6b1ca0f0b83aa2103f1e454739665e1b2802b90b3137fc79ccaa8c242ae48e4e"; };
+  # NB. sha256 is of the .tar.bz2 archive (see php.net/downloads and php.net/releases)
+  php74 = generic { version = "7.4.22"; sha256 = "5022bbca661bc1ab5dfaee72873bcd0f0980d9dd34f980a682029496f51caae1"; };
   composer74 = composer php74;
 
-  php73 = generic { version = "7.3.13"; sha256 = "5c7b89062814f3c3953d1518f63ed463fd452929e3a37110af4170c5d23267bc"; };
+  php73 = generic { version = "7.3.29"; sha256 = "a83a2878140bd86935f0046bbfe92672c8ab688fbe4ccf9704add6b9605ee4d0"; };
   composer73 = composer php73;
 
-  php72 = generic { version = "7.2.26"; sha256 = "f36d86eecf57ff919d6f67b064e1f41993f62e3991ea4796038d8d99c74e847b"; };
+  php72 = generic { version = "7.2.34"; sha256 = "0e5816d668a2bb14aca68cef8c430430bd86c3c5233f6c427d1a54aac127abcf"; };
   composer72 = composer php72;
 
   php71 = generic { version = "7.1.33"; sha256 = "95a5e5f2e2b79b376b737a82d9682c91891e60289fa24183463a2aca158f4f4b"; };

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,4 +1,7 @@
 # Entrypoint for derivations consuming the overlay (see default.nix).
-import <nixpkgs> {
+let
+  nixpkgs = builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/32fc8b9134c5fd56851ba1845f04d17484ea7170.tar.gz";
+in
+import nixpkgs {
   overlays = [(import ./overlay.nix)];
 }


### PR DESCRIPTION
This PR introduces two changes:

1. It pins Nixpkgs to a specific revision. This allows us to control the state of the world when we build software and images, giving us the ability to upgrade nixpkgs at our own pace.
2. It bumps PHP and Node.js versions to the latest available patches for the major/minor versions that we support for these images.