### PR TITLE
Change config.Cmd to array as required by BuildKit

### DIFF
--- a/f1ux/generic.nix
+++ b/f1ux/generic.nix
@@ -90,7 +90,7 @@ dockerTools.buildLayeredImage {
   ];
 
   config = {
-    Cmd = "${bashInteractive}/bin/bash";
+    Cmd = [ "${bashInteractive}/bin/bash" ];
 
     WorkingDir = "/app";
 

--- a/gesso2/generic.nix
+++ b/gesso2/generic.nix
@@ -50,7 +50,7 @@ dockerTools.buildLayeredImage {
   ];
 
   config = {
-    Cmd = "${busybox}/bin/sh";
+    Cmd = [ "${busybox}/bin/sh" ];
     WorkingDir = "/app";
     Env = [
       "PATH=${util.dockerPath}"


### PR DESCRIPTION
This PR updates image configuration to use an array for the default command. Docker allows this, but it causes BuildKit-based builds to fail with a deserialization error ("cannot unmarshal string into Go struct field ImageConfig.config.Cmd of type []string").

By updating configuration, we can remove the need to disable BuildKit during builds using these images.