### PR TITLE
DEVTOOLS-518: PHP 8.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,30 +18,35 @@ This repo builds multiple images for older Forum One themes. We provide builds f
 | v4           | 7.2         | 2.3          | forumone/f1ux:node-v4-php-7.2-ruby-2.3  |
 | v4           | 7.3         | 2.3          | forumone/f1ux:node-v4-php-7.3-ruby-2.3  |
 | v4           | 7.4         | 2.3          | forumone/f1ux:node-v4-php-7.4-ruby-2.3  |
+| v4           | 8.0         | 2.3          | forumone/f1ux:node-v4-php-8.0-ruby-2.3  |
 | v6           | 5.6         | 2.3          | forumone/f1ux:node-v6-php-5.6-ruby-2.3  |
 | v6           | 7.0         | 2.3          | forumone/f1ux:node-v6-php-7.0-ruby-2.3  |
 | v6           | 7.1         | 2.3          | forumone/f1ux:node-v6-php-7.1-ruby-2.3  |
 | v6           | 7.2         | 2.3          | forumone/f1ux:node-v6-php-7.2-ruby-2.3  |
 | v6           | 7.3         | 2.3          | forumone/f1ux:node-v6-php-7.3-ruby-2.3  |
 | v6           | 7.4         | 2.3          | forumone/f1ux:node-v6-php-7.4-ruby-2.3  |
+| v6           | 8.0         | 2.3          | forumone/f1ux:node-v6-php-8.0-ruby-2.3  |
 | v8           | 5.6         | 2.3          | forumone/f1ux:node-v8-php-5.6-ruby-2.3  |
 | v8           | 7.0         | 2.3          | forumone/f1ux:node-v8-php-7.0-ruby-2.3  |
 | v8           | 7.1         | 2.3          | forumone/f1ux:node-v8-php-7.1-ruby-2.3  |
 | v8           | 7.2         | 2.3          | forumone/f1ux:node-v8-php-7.2-ruby-2.3  |
 | v8           | 7.3         | 2.3          | forumone/f1ux:node-v8-php-7.3-ruby-2.3  |
 | v8           | 7.4         | 2.3          | forumone/f1ux:node-v8-php-7.4-ruby-2.3  |
+| v8           | 8.0         | 2.3          | forumone/f1ux:node-v8-php-8.0-ruby-2.3  |
 | v10          | 5.6         | 2.3          | forumone/f1ux:node-v10-php-5.6-ruby-2.3 |
 | v10          | 7.0         | 2.3          | forumone/f1ux:node-v10-php-7.0-ruby-2.3 |
 | v10          | 7.1         | 2.3          | forumone/f1ux:node-v10-php-7.1-ruby-2.3 |
 | v10          | 7.2         | 2.3          | forumone/f1ux:node-v10-php-7.2-ruby-2.3 |
 | v10          | 7.3         | 2.3          | forumone/f1ux:node-v10-php-7.3-ruby-2.3 |
 | v10          | 7.4         | 2.3          | forumone/f1ux:node-v10-php-7.4-ruby-2.3 |
+| v10          | 8.0         | 2.3          | forumone/f1ux:node-v10-php-8.0-ruby-2.3 |
 | v12          | 5.6         | 2.3          | forumone/f1ux:node-v12-php-5.6-ruby-2.3 |
 | v12          | 7.0         | 2.3          | forumone/f1ux:node-v12-php-7.0-ruby-2.3 |
 | v12          | 7.1         | 2.3          | forumone/f1ux:node-v12-php-7.1-ruby-2.3 |
 | v12          | 7.2         | 2.3          | forumone/f1ux:node-v12-php-7.2-ruby-2.3 |
 | v12          | 7.3         | 2.3          | forumone/f1ux:node-v12-php-7.3-ruby-2.3 |
 | v12          | 7.4         | 2.3          | forumone/f1ux:node-v12-php-7.4-ruby-2.3 |
+| v12          | 8.0         | 2.3          | forumone/f1ux:node-v12-php-8.0-ruby-2.3 |
 
 </details>
 
@@ -58,30 +63,35 @@ This repo builds multiple images for older Forum One themes. We provide builds f
 | v4           | 7.2         | forumone/gesso:2-node-v4-php-7.2  |
 | v4           | 7.3         | forumone/gesso:2-node-v4-php-7.3  |
 | v4           | 7.4         | forumone/gesso:2-node-v4-php-7.4  |
+| v4           | 8.0         | forumone/gesso:2-node-v4-php-8.0  |
 | v6           | 5.6         | forumone/gesso:2-node-v6-php-5.6  |
 | v6           | 7.0         | forumone/gesso:2-node-v6-php-7.0  |
 | v6           | 7.1         | forumone/gesso:2-node-v6-php-7.1  |
 | v6           | 7.2         | forumone/gesso:2-node-v6-php-7.2  |
 | v6           | 7.3         | forumone/gesso:2-node-v6-php-7.3  |
 | v6           | 7.4         | forumone/gesso:2-node-v6-php-7.4  |
+| v6           | 8.0         | forumone/gesso:2-node-v6-php-8.0  |
 | v8           | 5.6         | forumone/gesso:2-node-v8-php-5.6  |
 | v8           | 7.0         | forumone/gesso:2-node-v8-php-7.0  |
 | v8           | 7.1         | forumone/gesso:2-node-v8-php-7.1  |
 | v8           | 7.2         | forumone/gesso:2-node-v8-php-7.2  |
 | v8           | 7.3         | forumone/gesso:2-node-v8-php-7.3  |
 | v8           | 7.4         | forumone/gesso:2-node-v8-php-7.4  |
+| v8           | 8.0         | forumone/gesso:2-node-v8-php-8.0  |
 | v10          | 5.6         | forumone/gesso:2-node-v10-php-5.6 |
 | v10          | 7.0         | forumone/gesso:2-node-v10-php-7.0 |
 | v10          | 7.1         | forumone/gesso:2-node-v10-php-7.1 |
 | v10          | 7.2         | forumone/gesso:2-node-v10-php-7.2 |
 | v10          | 7.3         | forumone/gesso:2-node-v10-php-7.3 |
 | v10          | 7.4         | forumone/gesso:2-node-v10-php-7.4 |
+| v10          | 8.0         | forumone/gesso:2-node-v10-php-8.0 |
 | v12          | 5.6         | forumone/gesso:2-node-v12-php-5.6 |
 | v12          | 7.0         | forumone/gesso:2-node-v12-php-7.0 |
 | v12          | 7.1         | forumone/gesso:2-node-v12-php-7.1 |
 | v12          | 7.2         | forumone/gesso:2-node-v12-php-7.2 |
 | v12          | 7.3         | forumone/gesso:2-node-v12-php-7.3 |
 | v12          | 7.4         | forumone/gesso:2-node-v12-php-7.4 |
+| v12          | 8.0         | forumone/gesso:2-node-v12-php-8.0 |
 
 </details>
 

--- a/f1ux/default.nix
+++ b/f1ux/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   nodeKeys = [ "12" "10" "8" "6" "4" ];
-  phpKeys = [ "56" "70" "71" "72" "73" "74" ];
+  phpKeys = [ "56" "70" "71" "72" "73" "74" "80" ];
 
   mkImage = nodeKey: phpKey:
     let

--- a/gesso2/default.nix
+++ b/gesso2/default.nix
@@ -7,7 +7,7 @@
 }:
 let
   nodeKeys = [ "12" "10" "8" "6" "4" ];
-  phpKeys = [ "56" "70" "71" "72" "73" "74" ];
+  phpKeys = [ "56" "70" "71" "72" "73" "74" "80" ];
 
   mkImage = nodeKey: phpKey:
     let

--- a/node.nix
+++ b/node.nix
@@ -96,7 +96,7 @@ let
 
 in rec {
   # The sha256 digest here is for the .tar.xz of the Node sources
-  node12 = generic { version = "v12.22.4"; sha256 = "44cd4eab131e5282fc923e9e720d983a0b44c12e4aa4f6c3598dc97ae1e4cd4c"; };
+  node12 = generic { version = "v12.22.10"; sha256 = "ad4c8891d54a2c9bb6af436956deead5986b9698b06e6c6d616de429cfb5393a"; };
   grunt12 = grunt node12;
 
   node10 = generic { version = "v10.24.1"; sha256 = "d72fc2c244603b4668da94081dc4d6067d467fdfa026e06a274012f16600480c"; };

--- a/php.nix
+++ b/php.nix
@@ -162,10 +162,13 @@ let
 in
 rec {
   # NB. sha256 is of the .tar.bz2 archive (see php.net/downloads and php.net/releases)
-  php74 = generic { version = "7.4.22"; sha256 = "5022bbca661bc1ab5dfaee72873bcd0f0980d9dd34f980a682029496f51caae1"; };
+  php80 = generic { version = "8.0.16"; sha256 = "f49f8181ee29463a0d23a0c65969e92d58fee8ac564df917cff58e48d65e1849"; };
+  composer80 = composer php80;
+
+  php74 = generic { version = "7.4.28"; sha256 = "2085086a863444b0e39547de1a4969fd1c40a0c188eb58fab2938b649b0c4b58"; };
   composer74 = composer php74;
 
-  php73 = generic { version = "7.3.29"; sha256 = "a83a2878140bd86935f0046bbfe92672c8ab688fbe4ccf9704add6b9605ee4d0"; };
+  php73 = generic { version = "7.3.33"; sha256 = "f412487d7d953437e7978a0d7b6ec99bf4a85cf3378014438a8577b89535451a"; };
   composer73 = composer php73;
 
   php72 = generic { version = "7.2.34"; sha256 = "0e5816d668a2bb14aca68cef8c430430bd86c3c5233f6c427d1a54aac127abcf"; };


### PR DESCRIPTION
This PR adds PHP 8.0 to the PHP versions for both the f1ux and Gesso 2 images built from this repository.